### PR TITLE
Set content-type meta data on objects

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -35,11 +35,12 @@ func NewLogger(debug, onlyShowErrors bool) *Logger {
 	return l
 }
 
-// Config contains paths and configuration for local and remote file operations
+// Config contains common paths and configuration
 type Config struct {
 	S3Service    s3iface.S3API
 	Bucket       string
 	BucketPrefix string
+	DryRun       bool
 }
 
 // A FileStat describes a local and remote file and can contain an error if the information

--- a/structs.go
+++ b/structs.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"io/ioutil"
 	"log"
 	"os"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 // Logger wraps loggers for stdout, stderr and debug output


### PR DESCRIPTION
Currently, the content-type meta data in S3 get set to the default application/octet-stream which is normally not a problem unless you want to serve the content directly from the S3 bucket.